### PR TITLE
button.vue: Set outline to 0px.

### DIFF
--- a/src/components/button.vue
+++ b/src/components/button.vue
@@ -31,5 +31,6 @@ export default {
 	border: 0px solid white;
 	color: white;
 	background-color: transparent;
+	outline: 0px;
 }
 </style>


### PR DESCRIPTION
Otherwise the outline appears in browsers like chrome, which is
a bit offputting. See the image with the outline around the play button

![image](https://user-images.githubusercontent.com/1478220/87223678-2d825300-c37f-11ea-9013-753067b4ece0.png)
