### PR TITLE
Avoid operating on video data before loaded data.

### DIFF
--- a/src/components/videoPlaceholder.vue
+++ b/src/components/videoPlaceholder.vue
@@ -67,6 +67,9 @@ export default {
 
 	methods:{
 		atProgress (e) {
+			if (typeof (this.$refs.video.buffered) === 'undefined' || this.$refs.video.buffered.length <= 0) {
+				return // we are not yet ready as data is not yet available
+			}
 			var range = 0;
 			var bf = this.$refs.video.buffered;
 			var time = this.$refs.video.currentTime;


### PR DESCRIPTION
The even handler was running before video data was loaded leading to 
Uncaught IndexSizeError on ranges.
Now we just disregard the progress event until we have all the buffered information in.