### PR TITLE
showcase: Fix wrong video-placeholder-src in basic setup

### DIFF
--- a/src/showcase/basicPlayer.vue
+++ b/src/showcase/basicPlayer.vue
@@ -14,7 +14,7 @@
 
 				<vue-player 
 					src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
-					video-placeholder-src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg"
+					video-placeholder-src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
 					poster="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg"
 					title="I'm a title for this video"
 					playsinline


### PR DESCRIPTION
Instead of a video the video-placeholder-src was an image and this led to the placeholder failing the on hover play call. Fixed the src URL to point to the MP4 video