### PR TITLE
Added support for <source> sources.

### DIFF
--- a/PLAYER.md
+++ b/PLAYER.md
@@ -7,6 +7,8 @@ A must have html5 video player made in VueJS
 ## slots
 
 - `controls` Use this slot to replace the controls
+- `sources` Use this slot to add `<source>` elements to the video player, as well as fallbacks. When this slot is used the `src` property is ignored. See [<source> docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source)
+- `video-placeholder-sources` Use this slot to add `<source>` elements to the video placeholder player, as well as fallbacks. When this slot is used the `src` property is ignored. See [<source> docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source)
 
 ## props
 
@@ -23,7 +25,7 @@ A must have html5 video player made in VueJS
 - `src` **_String|Array_** (_required_)
 
   Define the source for the video tag.
-  if array uses the src-index to pick one
+  if array uses the src-index to pick one. Ignored if sources slot used.
 
 - `src-index` **_ArrayExpression_** (_optional_)
 
@@ -48,7 +50,7 @@ A must have html5 video player made in VueJS
 
 - `video-placeholder-src` **_String_** (_optional_)
 
-  if you want a video teaser you can use this, will be played with-out sound
+  if you want a video teaser you can use this, will be played without sound. Ignored if `video-placeholder-source` slot is used.
 
 - `volume` **_Number_** (_optional_) `default: undefined`
 

--- a/src/components/player.vue
+++ b/src/components/player.vue
@@ -24,7 +24,9 @@
 		@volumechange="atVolumechange"
 		@ended="atEnded"
 		@stalled="test"
-	/>
+	>
+		<slot name="sources"></slot>
+	</video>
 
 	<video-placeholder
 		:src="videoPlaceholderSrc"
@@ -32,7 +34,11 @@
 		:preview-on-mouse="previewOnMouse"
 		:mouseover="mouseover"
 		v-if="!started"
-	/>
+	>
+		<template slot="video-placeholder-sources">
+			<slot name="video-placeholder-sources"></slot>
+		</template>
+	</video-placeholder>
 
 	<div 
 		:class="overlayClass"
@@ -180,7 +186,6 @@ export default {
 	   * if array uses the src-index to pick one
        */
 		src: {
-			required: true,
 			type: [String, Array]
 		},
 
@@ -360,7 +365,7 @@ export default {
        * @private
        */
 		atEnded () {
-			if (typeof this.src != 'string') {
+			if (typeof this.src != 'string' || !this.$slots.sources) {
 				/**
 				 * if src is a array, at the end of the video emits the new src-index
 				 */
@@ -493,6 +498,10 @@ export default {
 
 		}
 	},
+    mounted() {
+      if (this.$slots.sources) // We need to remove the src attribute if we have the sources slot otherwise src="" will load a local directory
+        this.$refs.video.removeAttribute("src");
+    },
 
 	computed: {
 		/**
@@ -589,7 +598,8 @@ export default {
        * @private
        */
 		srcComputed () {
-			if (typeof this.src == 'string') return this.src
+			if (this.$slots.sources) return ""
+			else if (typeof this.src == 'string') return this.src
 
 			return this.src[this.srcIndex]
 		},

--- a/src/components/videoPlaceholder.vue
+++ b/src/components/videoPlaceholder.vue
@@ -7,7 +7,7 @@
 	/>
 
 	<video 
-		:src="src"
+		:src="computedSrc"
 		:controls="false"
 		class="placeholder"
 		:loop="true"
@@ -19,8 +19,9 @@
 		ref="video"
 		@loadstart="loadVideo"
 		@progress="atProgress"
-
-	/>
+	>
+		<slot name="video-placeholder-sources"></slot>
+	</video>
 
 	<img
 		:src="poster"
@@ -91,8 +92,26 @@ export default {
 			})
 		},
 	},
-
+  watch: {
+		ifVideo: {
+			immediate: true,
+			async handler(newValue) {
+				if (newValue) {
+					// Wait until the DOM is updated
+					await this.$nextTick();
+					if (this.$refs.video && this.$slots["video-placeholder-sources"]) {
+						this.$refs.video.removeAttribute("src")
+					}
+				}
+			},
+		},
+	},
 	computed: {
+		computedSrc() {
+			if (this.$slots["video-placeholder-sources"])
+				return false
+			return this.src
+		},
 		ifVideo () {
 			let result = false
 
@@ -111,11 +130,11 @@ export default {
 			let result = false 
 			
 			if (this.previewOnMouse) {
-				if (this.src && this.mouseover) result = true
+				if ((this.src || this.$slots["video-placeholder-sources"]) && this.mouseover) result = true
 			} 
 
 			if (!this.previewOnMouse) {
-				if (this.src) result = true
+				if (this.src || this.$slots["video-placeholder-sources"]) result = true
 			}
 
 			return result

--- a/src/showcase/basicPlayer.vue
+++ b/src/showcase/basicPlayer.vue
@@ -4,7 +4,16 @@
 			<h2 class="title ">Basic setup</h2>
 
 			<p class="subtitle">
-				With a `poster` image showing and alterates to a video teaser (video-placeholder-src) when the mouse is over and a little title
+				With a `poster` image showing it changes to a video teaser (v-slot:video-placeholder-sources) when the mouse is over the component.
+				It also sets a small title.
+			</p>
+			<p>
+				If only a single source is required for the placeholder you don't need to use the slot and instead can set the `video-placeholder-src` property.
+			</p>
+			<p>
+				In the same way, for the main video if a single source is required you don't need to use the slot and can set the `src` property.
+				With the `v-slot:sources` and `v-slot:video-placeholder-sources` you can support devices with different codec
+				preferences.
 			</p>
 		</div>
 			
@@ -12,14 +21,18 @@
 			<div>
 				<h3 class="subtitle">Example</h3>
 
-				<vue-player 
-					src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
-					video-placeholder-src="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg"
+				<vue-player
 					poster="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg"
 					title="I'm a title for this video"
 					playsinline
 					preview-on-mouse
 				>
+					<template v-slot:sources>
+						<source src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"/>
+					</template>
+					<template v-slot:video-placeholder-sources>
+						<source src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"/>
+					</template>
 				</vue-player>
 			</div>
 
@@ -44,14 +57,19 @@ export default {
 
 	data () {
 		return {
-			html: `<vue-player 
-	src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
-	video-placeholder-src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
-	poster="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg"
-	title="I'm a title for this video"
-	playsinline
-	preview-on-mouse
-></vue-player>`
+			html: `<vue-player
+\tposter="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/images/BigBuckBunny.jpg"
+\ttitle="I'm a title for this video"
+\ttplaysinline
+\tpreview-on-mouse
+\t>
+\t\t<template v-slot:sources>
+\t\t\t<source src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"/>
+\t\t</template>
+\t\t<template v-slot:video-placeholder-sources>
+\t\t\t<source src="http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"/>
+\t\t</template>
+</vue-player>`
 		}
 	}
 }

--- a/tests/unit/player.spec.js
+++ b/tests/unit/player.spec.js
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils'
+import { shallowMount, mount } from '@vue/test-utils'
 import Player from '@/components/player.vue'
 import pButton from '@/components/button.vue'
 
@@ -19,6 +19,22 @@ describe('Player.vue', () => {
     expect(wrapper.html()).toContain(src)
     expect(wrapper.props().src).toMatch(src)
   })
+
+  it("renders sources slot even when props.src is passed", () => {
+	const src = "http://clips.vorwaerts-gmbh.de/VfE_html5.mp4";
+	const sources_el = '<source src="foo.webm" type="video/webm">'
+	const wrapper = shallowMount(Player, {
+		propsData: { src },
+		slots: {
+			sources: sources_el,
+		},
+	});
+
+	// Check the slot content is correctly rendered
+	expect(wrapper.html()).toContain(sources_el);
+	expect(wrapper.html()).not.toContain(src); // Ensure src prop content is not rendered
+	expect(wrapper.props().src).toMatch(src);
+	});
 
   it('renders props.src when passed', () => {
 	const src = [ '0', '1']
@@ -80,6 +96,20 @@ describe('Player.vue', () => {
 
     expect(wrapper.html()).toContain(videoPlaceholderSrc)
   })
+
+	it('renders slot:video-placeholder-sources even when when videoPlaceholder passed', () => {
+		const videoPlaceholderSrc = 'http://www.test.com'
+		const sources_el = '<source src="foo.webm" type="video/webm">'
+		const wrapper = mount(Player, {
+			propsData: { src: '', videoPlaceholderSrc },
+			slots: {
+				"video-placeholder-sources": sources_el,
+			},
+		})
+
+		expect(wrapper.html()).not.toContain(videoPlaceholderSrc)
+		expect(wrapper.html()).toContain(sources_el);
+	})
 
   it('renders props.volume when passed', () => {
 	const volume  = 0.5


### PR DESCRIPTION
Using <source> elements to set the video source allows the browser to choose the most appropriate codec for the device. It also allows different CDNs and fallbacks on video source.

Nothing important changed in the behavior except that the slots have priority over the src properties.